### PR TITLE
Base image on Fedora-28 rather than Fedora-25 / Bump Qpid Proton dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:25
+FROM fedora:28
 RUN dnf -y install glibc.i686 cyrus-sasl-lib cyrus-sasl-plain libuuid openssl python gettext hostname iputils libwebsockets-devel && dnf -y update && dnf clean all
 ADD qpid-proton-image.tar.gz qpid-dispatch-image.tar.gz /
 ARG version=latest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT_NAME=qdrouterd
 PWD=$(shell pwd)
 ROUTER_SOURCE_URL=https://dist.apache.org/repos/dist/dev/qpid/dispatch/1.3.0-rc1/qpid-dispatch-1.3.0.tar.gz
-PROTON_SOURCE_URL=http://archive.apache.org/dist/qpid/proton/0.23.0/qpid-proton-0.23.0.tar.gz
+PROTON_SOURCE_URL=http://archive.apache.org/dist/qpid/proton/0.24.0/qpid-proton-0.24.0.tar.gz
 
 all: build
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,3 +1,3 @@
-FROM fedora:25
+FROM fedora:28
 
 RUN dnf install -y gcc gcc-c++ make cmake libuuid-devel openssl-devel python-devel swig libwebsockets-devel wget patch findutils && dnf clean all -y


### PR DESCRIPTION
Bump OS base image from Fedora-25 to 28 and bump Qpid Proton dependency from 0.23.0 to 0.24.0.